### PR TITLE
Update gd32vf103.h

### DIFF
--- a/Firmware/GD32VF103_standard_peripheral/gd32vf103.h
+++ b/Firmware/GD32VF103_standard_peripheral/gd32vf103.h
@@ -180,7 +180,9 @@ typedef enum IRQn
 
 /* enum definitions */
 typedef enum {DISABLE = 0, ENABLE = !DISABLE} EventStatus, ControlStatus;
+#ifndef __cplusplus
 typedef enum {FALSE = 0, TRUE = !FALSE} bool;
+#endif
 typedef enum {RESET = 0, SET = 1,MAX = 0X7FFFFFFF} FlagStatus;
 typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrStatus;
 


### PR DESCRIPTION
### The GD32VF103 header comes with a hardcoded `typedef` for __bool__.

- This bool redefinition breaks C++ application builds.
- This small fix should work fine with both C and C++ applications.